### PR TITLE
Fix: ipcRenderer error

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ cd frontend
 npm start
 ```
 
+**Having issues installing frontend? See this [debugging guide](https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/400)**
+
 
 ## Roadmap
 

--- a/frontend/src/renderer/index.tsx
+++ b/frontend/src/renderer/index.tsx
@@ -5,9 +5,8 @@ const container = document.getElementById('root') as HTMLElement;
 const root = createRoot(container);
 root.render(<App />);
 
-// calling IPC exposed from preload script
-window.electron.ipcRenderer.once('ipc-example', (arg) => {
-  // eslint-disable-next-line no-console
-  console.log(arg);
-});
-window.electron.ipcRenderer.sendMessage('ipc-example', ['ping']);
+// https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/3192#issuecomment-1219151506
+// window.electron.ipcRenderer.once('ipc-example', (arg) => {
+//   console.log(arg);
+// });
+// window.electron.ipcRenderer.sendMessage('ipc-example', ['ping']);


### PR DESCRIPTION
Issue: https://github.com/grumpyp/aixplora/issues/30

The change is based on this https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/3192#issuecomment-1219151506
I'm sure there's a better way to do this, but this is what I was able to find given I don't have any experience working with an electron app.

So far, on my Windows machine, the following error is gone
```
TypeError
Cannot read properties of undefined (reading 'ipcRenderer')
Call Stack
 ./src/renderer/index.tsx
  renderer.dev.js:66999:17
 options.factory
  renderer.dev.js:78064:31
 webpack_require
  renderer.dev.js:77510:33
 undefined
  renderer.dev.js:78649:37
 undefined
  renderer.dev.js:78652:12
 webpackUniversalModuleDefinition
  renderer.dev.js:7:11
 undefined
  renderer.dev.js:10:3
```

@grumpyp could you verify, if this doesn't break anything on Mac

Also added a link to the troubleshooting guide https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/400
The frontend was bootstrapped from this project. Turns out other people have also faced similar issues installing gyp.