### PR TITLE
Validate api key before saving config

### DIFF
--- a/backend/config/utils.py
+++ b/backend/config/utils.py
@@ -1,0 +1,16 @@
+import openai
+
+def is_valid_api_key(openai_api_key: str):
+    openai.api_key = openai_api_key
+    try:
+        openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant."}
+            ]
+        )
+        print('Validated api key')
+        return { 'validApiKey': True }
+    except Exception as e:
+        print('Error validating api key: ', e)
+        return { 'validApiKey': False }

--- a/backend/config/utils.py
+++ b/backend/config/utils.py
@@ -11,5 +11,8 @@ def is_valid_api_key(openai_api_key: str):
         )
         return { 'validApiKey': True }
     except Exception as e:
-        return { 'validApiKey': False }
+        return {
+            'validApiKey': False,
+            'message': e.error.message
+        }
     

--- a/backend/config/utils.py
+++ b/backend/config/utils.py
@@ -12,3 +12,4 @@ def is_valid_api_key(openai_api_key: str):
         return { 'validApiKey': True }
     except Exception as e:
         return { 'validApiKey': False }
+    

--- a/backend/config/utils.py
+++ b/backend/config/utils.py
@@ -9,8 +9,6 @@ def is_valid_api_key(openai_api_key: str):
                 {"role": "system", "content": "You are a helpful assistant."}
             ]
         )
-        print('Validated api key')
         return { 'validApiKey': True }
     except Exception as e:
-        print('Error validating api key: ', e)
         return { 'validApiKey': False }

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,6 +9,7 @@ from schemas.config import Config
 from schemas.question import Question, Document
 from schemas.file import UploadRequestBody
 from schemas.prompt import Prompt
+from config import utils
 from utils import FILE_HANDLERS
 from embeddings.index_files import Genie
 from loaders.website_loader import extract_text_from_website
@@ -67,6 +68,9 @@ async def posthog_middleware(request: Request, call_next):
 
     return response
 
+@app.post("/config/validate-api-key/")
+def validate_api_key(config: Config):
+    return utils.is_valid_api_key(config.apiKey)
 
 @app.get("/config/")
 def get_config():
@@ -75,7 +79,7 @@ def get_config():
         return False
     return True
 
-
+# TODO: This is where the api key gets set
 @app.post("/config/")
 def add_config(config: Config):
     db = Database().get_session()

--- a/backend/main.py
+++ b/backend/main.py
@@ -79,7 +79,6 @@ def get_config():
         return False
     return True
 
-# TODO: This is where the api key gets set
 @app.post("/config/")
 def add_config(config: Config):
     db = Database().get_session()

--- a/frontend/src/renderer/components/ErrorNotification.tsx
+++ b/frontend/src/renderer/components/ErrorNotification.tsx
@@ -1,8 +1,8 @@
 import { notifications } from '@mantine/notifications';
 
-export function ErrorNotification(endpoint, method, customMsg=null) {
+export function ErrorNotification(endpoint, method, customMsg=null, title="Error!") {
     notifications.show({
-        title: "Error!",
+        title: title,
         message: customMsg || "An error occurred with the " + method + " request to endpoint " + endpoint,
         color: 'red',
         autoClose: false,

--- a/frontend/src/renderer/components/ErrorNotification.tsx
+++ b/frontend/src/renderer/components/ErrorNotification.tsx
@@ -1,9 +1,9 @@
 import { notifications } from '@mantine/notifications';
 
-export function ErrorNotification(endpoint, method) {
+export function ErrorNotification(endpoint, method, customMsg=null) {
     notifications.show({
         title: "Error!",
-        message: "An error occurred with the " + method + " request to endpoint " + endpoint,
+        message: customMsg || "An error occurred with the " + method + " request to endpoint " + endpoint,
         color: 'red',
         autoClose: false,
       });

--- a/frontend/src/renderer/pages/config/Config.tsx
+++ b/frontend/src/renderer/pages/config/Config.tsx
@@ -21,7 +21,7 @@ function saveConfig(OPENAI_API_KEY: string, model: string, embeddingsmodel: stri
 
     // validate api key before saving config
     return apiCall('/config/validate-api-key', 'POST', payload).then((response) => {
-        if (response.data.validApiKey === false) return ErrorNotification('/config/validate-api-key', 'POST', response?.data.message);
+        if (response?.data.validApiKey === false) return ErrorNotification('/config/validate-api-key', 'POST', response?.data.message, 'Invalid OpenAI API Key');
 
         apiCall('/config', 'POST', payload).then((response) => {
             const fetchedConfig = response.data;

--- a/frontend/src/renderer/pages/config/Config.tsx
+++ b/frontend/src/renderer/pages/config/Config.tsx
@@ -21,7 +21,7 @@ function saveConfig(OPENAI_API_KEY: string, model: string, embeddingsmodel: stri
 
     // validate api key before saving config
     return apiCall('/config/validate-api-key', 'POST', payload).then((response) => {
-        if (response.data.validApiKey === false) return ErrorNotification('/config/validate-api-key', 'POST');
+        if (response.data.validApiKey === false) return ErrorNotification('/config/validate-api-key', 'POST', response?.data.message);
 
         apiCall('/config', 'POST', payload).then((response) => {
             const fetchedConfig = response.data;
@@ -68,7 +68,6 @@ function saveConfig(OPENAI_API_KEY: string, model: string, embeddingsmodel: stri
 //         });
 // }
 }
-
 function Config() {
     const isConnected = useSelector((state) => state.connectedExternalDb.value);
     const dispatch = useDispatch();

--- a/frontend/src/renderer/pages/config/Config.tsx
+++ b/frontend/src/renderer/pages/config/Config.tsx
@@ -67,27 +67,6 @@ function saveConfig(OPENAI_API_KEY: string, model: string, embeddingsmodel: stri
 //             return false;
 //         });
 // }
-    // return apiCall('/config', 'POST', payload).then((response) => {
-    //         const fetchedConfig = response.data;
-    //         console.log(fetchedConfig);
-
-    //         if (Object.keys(fetchedConfig).length === 0) {
-    //             return false;
-    //         }
-
-    //         // The fetched config is not an empty object, save it and return true
-    //         localStorage.setItem('config', JSON.stringify(fetchedConfig));
-    //         console.log(fetchedConfig);
-    //         window.location.reload();
-
-    //         return true;
-    //     }
-    // )
-    //     .catch((error) => {
-    //             console.log('Error fetching config:', error);
-    //             return false;
-    //         }
-    //     );
 }
 
 function Config() {

--- a/frontend/src/renderer/pages/config/Config.tsx
+++ b/frontend/src/renderer/pages/config/Config.tsx
@@ -10,7 +10,7 @@ import {connect, disconnect} from '../../store/slices/externalDbSlice';
 import {apiCall} from "../../utils/api";
 import {useState} from "react";
 import PromptConfiguration from "./PromptConfig";
-
+import { ErrorNotification } from "../../../renderer/components/ErrorNotification";
 
 function saveConfig(OPENAI_API_KEY: string, model: string, embeddingsmodel: string) {
     const payload = {
@@ -18,6 +18,35 @@ function saveConfig(OPENAI_API_KEY: string, model: string, embeddingsmodel: stri
         model: model,
         embeddingsModel: embeddingsmodel
     };
+
+    // validate api key before saving config
+    return apiCall('/config/validate-api-key', 'POST', payload).then((response) => {
+        if (response.data.validApiKey === false) return ErrorNotification('/config/validate-api-key', 'POST');
+
+        apiCall('/config', 'POST', payload).then((response) => {
+            const fetchedConfig = response.data;
+            console.log(fetchedConfig);
+
+            if (Object.keys(fetchedConfig).length === 0) {
+                return false;
+            }
+
+            // The fetched config is not an empty object, save it and return true
+            localStorage.setItem('config', JSON.stringify(fetchedConfig));
+            console.log(fetchedConfig);
+            window.location.reload();
+
+            return true;
+        })
+        .catch((error) => {
+                console.log('Error fetching config:', error);
+                return false;
+            }
+        );
+    }).catch((error) => {
+        console.log('error:', error)
+        return false;
+    });
 //     return axios.post(`${config.REACT_APP_BACKEND_URL}/config`, payload)
 //         .then((response) => {
 //             const fetchedConfig = response.data;
@@ -38,27 +67,27 @@ function saveConfig(OPENAI_API_KEY: string, model: string, embeddingsmodel: stri
 //             return false;
 //         });
 // }
-    return apiCall('/config', 'POST', payload).then((response) => {
-            const fetchedConfig = response.data;
-            console.log(fetchedConfig);
+    // return apiCall('/config', 'POST', payload).then((response) => {
+    //         const fetchedConfig = response.data;
+    //         console.log(fetchedConfig);
 
-            if (Object.keys(fetchedConfig).length === 0) {
-                return false;
-            }
+    //         if (Object.keys(fetchedConfig).length === 0) {
+    //             return false;
+    //         }
 
-            // The fetched config is not an empty object, save it and return true
-            localStorage.setItem('config', JSON.stringify(fetchedConfig));
-            console.log(fetchedConfig);
-            window.location.reload();
+    //         // The fetched config is not an empty object, save it and return true
+    //         localStorage.setItem('config', JSON.stringify(fetchedConfig));
+    //         console.log(fetchedConfig);
+    //         window.location.reload();
 
-            return true;
-        }
-    )
-        .catch((error) => {
-                console.log('Error fetching config:', error);
-                return false;
-            }
-        );
+    //         return true;
+    //     }
+    // )
+    //     .catch((error) => {
+    //             console.log('Error fetching config:', error);
+    //             return false;
+    //         }
+    //     );
 }
 
 function Config() {
@@ -66,7 +95,6 @@ function Config() {
     const dispatch = useDispatch();
     const [opened, {open, close}] = useDisclosure(false);
     const [focused, setFocused] = useState(false);
-
 
     const form = useForm({
         initialValues: {


### PR DESCRIPTION
## Behavior after this change
#### Invalid api key - exception information is bubbled up to the frontend

Invalid api key
![invalidApiKey1](https://github.com/grumpyp/aixplora/assets/57982138/03d93f55-0430-4842-aa1f-f3c9d6730b94)

Quota exceeded
![invalidApiKey2](https://github.com/grumpyp/aixplora/assets/57982138/55b06968-1848-47b4-91c7-8c443809b37e)



#### Valid api key
![image](https://github.com/grumpyp/aixplora/assets/57982138/3e621b64-c79c-47bf-9bde-181fe07d8f98)


We now make a test api call before saving config to the db. If the test api call fails, we display the ErrorNotification component, otherwise we save the config as normal
